### PR TITLE
Allow node to blacklist accounts set in JSON

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -334,9 +334,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 		}
 	}
 
-	if accounts := config.parseBlacklistedAccounts(); accounts != nil {
-		pool.blacklistedAccounts = accounts
-	}
+	pool.ReloadBlacklistedAccounts()
 
 	// Subscribe events from blockchain and start the main event loop.
 	pool.chainHeadSub = pool.chain.SubscribeChainHeadEvent(pool.chainHeadCh)
@@ -440,6 +438,13 @@ func (pool *TxPool) Stop() {
 // starts sending event to the given channel.
 func (pool *TxPool) SubscribeNewTxsEvent(ch chan<- NewTxsEvent) event.Subscription {
 	return pool.scope.Track(pool.txFeed.Subscribe(ch))
+}
+
+// ReloadBlacklistedAccounts reloads the blacklisted accounts.
+func (pool *TxPool) ReloadBlacklistedAccounts() {
+	if accounts := pool.config.parseBlacklistedAccounts(); accounts != nil {
+		pool.blacklistedAccounts = accounts
+	}
 }
 
 // GasPrice returns the current gas price enforced by the transaction pool.

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -299,6 +299,10 @@ func (b *EthAPIBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.S
 	return b.eth.TxPool().SubscribeNewTxsEvent(ch)
 }
 
+func (b *EthAPIBackend) ReloadBlacklistedAccounts() {
+	b.eth.TxPool().ReloadBlacklistedAccounts()
+}
+
 func (b *EthAPIBackend) Downloader() *downloader.Downloader {
 	return b.eth.Downloader()
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -214,6 +214,9 @@ func New(ctx *node.ServiceContext, config *Config) (*Ebakus, error) {
 	if config.TxPool.Journal != "" {
 		config.TxPool.Journal = ctx.ResolvePath(config.TxPool.Journal)
 	}
+	if config.TxPool.BlacklistedAccounts != "" {
+		config.TxPool.BlacklistedAccounts = ctx.ResolvePath(config.TxPool.BlacklistedAccounts)
+	}
 	eth.txPool = core.NewTxPool(config.TxPool, chainConfig, eth.blockchain)
 
 	// Permit the downloader to use the trie cache allowance during fast sync

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -182,6 +182,11 @@ func (s *PublicTxPoolAPI) Inspect() map[string]map[string]map[string]string {
 	return content
 }
 
+// ReloadBlacklistedaccounts reloads the blacklisted accounts JSON
+func (s *PublicTxPoolAPI) ReloadBlacklistedaccounts() {
+	s.b.ReloadBlacklistedAccounts()
+}
+
 // PublicAccountAPI provides an API to access accounts managed by this node.
 // It offers only methods that can retrieve accounts.
 type PublicAccountAPI struct {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -182,8 +182,8 @@ func (s *PublicTxPoolAPI) Inspect() map[string]map[string]map[string]string {
 	return content
 }
 
-// ReloadBlacklistedaccounts reloads the blacklisted accounts JSON
-func (s *PublicTxPoolAPI) ReloadBlacklistedaccounts() {
+// ReloadBlacklistedAccounts reloads the blacklisted accounts JSON
+func (s *PublicTxPoolAPI) ReloadBlacklistedAccounts() {
 	s.b.ReloadBlacklistedAccounts()
 }
 

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -79,6 +79,7 @@ type Backend interface {
 	Stats() (pending int, queued int)
 	TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
+	ReloadBlacklistedAccounts()
 
 	// Filter API
 	BloomStatus() (uint64, uint64)

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -738,8 +738,8 @@ web3._extend({
 	methods:
 	[
 		new web3._extend.Method({
-			name: 'reloadBlacklistedaccounts',
-			call: 'txpool_reloadBlacklistedaccounts',
+			name: 'reloadBlacklistedAccounts',
+			call: 'txpool_reloadBlacklistedAccounts',
 			params: 0
 		}),
 	],

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -735,7 +735,14 @@ web3._extend({
 const TxpoolJs = `
 web3._extend({
 	property: 'txpool',
-	methods: [],
+	methods:
+	[
+		new web3._extend.Method({
+			name: 'reloadBlacklistedaccounts',
+			call: 'txpool_reloadBlacklistedaccounts',
+			params: 0
+		}),
+	],
 	properties:
 	[
 		new web3._extend.Property({

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -225,6 +225,10 @@ func (b *LesApiBackend) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.S
 	return b.eth.txPool.SubscribeNewTxsEvent(ch)
 }
 
+func (b *LesApiBackend) ReloadBlacklistedAccounts() {
+	// do nothing on light client
+}
+
 func (b *LesApiBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription {
 	return b.eth.blockchain.SubscribeChainEvent(ch)
 }


### PR DESCRIPTION
This PR allows node to block accounts from sending TXs. For this a `blacklisted-accounts.json` file has to be created in the datadir with an array of accounts to be blacklisted.

```json
[
  "0x...",
  "0x..."
]
```